### PR TITLE
correct comment subsample mistake 1k / 0x03+1 --> 250Hz

### DIFF
--- a/MPU9250_BME280_BasicAHRS2_Butterfly.ino
+++ b/MPU9250_BME280_BasicAHRS2_Butterfly.ino
@@ -813,7 +813,7 @@ void initMPU9250()
   writeByte(MPU9250_ADDRESS, CONFIG, 0x03);  
 
  // Set sample rate = gyroscope output rate/(1 + SMPLRT_DIV)
-  writeByte(MPU9250_ADDRESS, SMPLRT_DIV, 0x03);  // Use a 200 Hz rate; a rate consistent with the filter update rate 
+  writeByte(MPU9250_ADDRESS, SMPLRT_DIV, 0x03);  // Use a 250 Hz rate; a rate consistent with the filter update rate 
                                     // determined inset in CONFIG above
  
  // Set gyroscope full scale range


### PR DESCRIPTION
Correct a comment mistake according to the MPU9250 documentation for sampling frequency and sub-sampling configuration.  